### PR TITLE
Updating torch.range to torch.arange

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "numpy",
         "scipy",
         "torch>=1.8",
-        "pytorch-lightning",
+        "pytorch-lightning>=1.4",
         # pypi release (only master) doesn't support OrderedDict typing
         # "typing-extensions",
     ],

--- a/torchsynth/profile.py
+++ b/torchsynth/profile.py
@@ -110,7 +110,7 @@ def run_lightning_module(
         # Run module with profiling
         pr = cProfile.Profile()
         pr.enable()
-        trainer.test(module, test_dataloaders=dataloader)
+        trainer.test(module, dataloaders=dataloader)
         pr.disable()
 
         s = io.StringIO()
@@ -132,7 +132,7 @@ def run_lightning_module(
             print(s.getvalue())
 
     else:
-        trainer.test(module, test_dataloaders=dataloader)
+        trainer.test(module, dataloaders=dataloader)
 
 
 def main():

--- a/torchsynth/synth.py
+++ b/torchsynth/synth.py
@@ -239,9 +239,9 @@ class AbstractSynth(LightningModule):
         Determine which samples are training examples if batch_idx is provided
         """
         if batch_idx is not None:
-            idxs = torch.range(
+            idxs = torch.arange(
                 self.batch_size * batch_idx,
-                self.batch_size * (batch_idx + 1) - 1,
+                self.batch_size * (batch_idx + 1),
                 device=self.device,
             )
             assert len(idxs) == self.batch_size


### PR DESCRIPTION
[`torch.range` is now deprecated](https://pytorch.org/docs/stable/generated/torch.range.html) and should be replaced with `torch.arange`, which is consistent with pythons built-in range. `torch.range` also was producing errors with high-valued ranges, see #377

Merge #380 into this first.