### PR TITLE
Codecov Action Fix

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         # Limit to coverage of source files in current directory
         coverage run -m examples.examples --source=.
-        coverage xml
+        coverage xml --omit "*_remote_module_non_scriptable.py"
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1.2.0
       with:


### PR DESCRIPTION
In more recent versions of torch it appears that a temporary file `_remote_module_non_scriptable.py` is created, which breaks codecov xml generation. This change omits that file during xml generation,