### PR TITLE
Add new_empty to Signal

### DIFF
--- a/examples/examples.py
+++ b/examples/examples.py
@@ -67,10 +67,10 @@ from torchsynth.module import (
     ADSR,
     VCA,
     ControlRateUpsample,
+    FmVCO,
     MonophonicKeyboard,
     Noise,
     SineVCO,
-    FmVCO,
 )
 from torchsynth.parameter import ModuleParameterRange
 

--- a/examples/simplesynth.py
+++ b/examples/simplesynth.py
@@ -11,19 +11,18 @@
 # +
 from typing import Optional
 
-import torch
 import IPython.display as ipd
+import torch
 
+from torchsynth.config import BASE_REPRODUCIBLE_BATCH_SIZE, SynthConfig
 from torchsynth.module import (
     ADSR,
+    VCA,
     ControlRateUpsample,
     MonophonicKeyboard,
     SquareSawVCO,
-    VCA,
 )
 from torchsynth.synth import AbstractSynth
-from torchsynth.config import SynthConfig, BASE_REPRODUCIBLE_BATCH_SIZE
-
 
 # -
 

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -1,0 +1,21 @@
+"""
+Tests for torch signals
+"""
+
+from copy import deepcopy
+
+import torch
+
+from torchsynth.signal import Signal
+
+
+class TestSignal:
+    """
+    Tests for Signal
+    """
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    def test_deepcopy(self):
+        signal = torch.zeros(1, 1).as_subclass(Signal)
+        print(deepcopy(signal))

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -2,8 +2,9 @@
 Tests for torch synths
 """
 
-import os
 import json
+import os
+
 import pytest
 import torch.nn
 from torch import tensor

--- a/torchsynth/__init__.py
+++ b/torchsynth/__init__.py
@@ -1,6 +1,6 @@
-from torchsynth.__info__ import (  # noqa: F401
+from torchsynth.__info__ import (
     __author__,
-    __author_email__,
+    __author_email__,  # noqa: F401
     __copyright__,
     __docs__,
     __homepage__,

--- a/torchsynth/__init__.py
+++ b/torchsynth/__init__.py
@@ -1,6 +1,6 @@
+from torchsynth.__info__ import __author_email__  # noqa: F401
 from torchsynth.__info__ import (
     __author__,
-    __author_email__,  # noqa: F401
     __copyright__,
     __docs__,
     __homepage__,

--- a/torchsynth/config.py
+++ b/torchsynth/config.py
@@ -8,7 +8,6 @@ from typing import Optional
 
 import torch
 
-
 #: This batch size is a nice trade-off between speed and memory consumption. On
 #: a typical GPU this consumes ~2.3GB of memory for the default Voice.
 #: Learn more about `batch processing <../performance/batch-processing.html>`_.

--- a/torchsynth/module.py
+++ b/torchsynth/module.py
@@ -8,8 +8,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torch import tensor
 from torch import Tensor as T
+from torch import tensor
 
 import torchsynth.util as util
 from torchsynth.config import BASE_REPRODUCIBLE_BATCH_SIZE, SynthConfig

--- a/torchsynth/signal.py
+++ b/torchsynth/signal.py
@@ -23,6 +23,6 @@ class Signal(torch.Tensor):
 
     def new_empty(self, *args, **kwargs):
         """
-        Implement (torch.Tensor.new_empty)[https://pytorch.org/docs/stable/generated/torch.Tensor.new_empty.html]
+        Implement [torch.Tensor.new_empty](https://pytorch.org/docs/stable/generated/torch.Tensor.new_empty.html) so that Signal can be [`deepcopy`](https://docs.python.org/3/library/copy.html#copy.deepcopy)ed.
         """
         return super().new_empty(*args, **kwargs).as_subclass(self.__class__)

--- a/torchsynth/signal.py
+++ b/torchsynth/signal.py
@@ -29,4 +29,5 @@ class Signal(torch.Tensor):
         so that Signal can be
         [`deepcopy`](https://docs.python.org/3/library/copy.html#copy.deepcopy)ed.
         """
+
         return super().new_empty(*args, **kwargs).as_subclass(self.__class__)

--- a/torchsynth/signal.py
+++ b/torchsynth/signal.py
@@ -20,3 +20,9 @@ class Signal(torch.Tensor):
     def num_samples(self):
         assert self.ndim == 2
         return self.shape[1]
+
+    def new_empty(self, *args, **kwargs):
+        """
+        Implement (torch.Tensor.new_empty)[https://pytorch.org/docs/stable/generated/torch.Tensor.new_empty.html]
+        """
+        return super().new_empty(*args, **kwargs).as_subclass(self.__class__)

--- a/torchsynth/signal.py
+++ b/torchsynth/signal.py
@@ -26,8 +26,9 @@ class Signal(torch.Tensor):
         """
             Implement
         [torch.Tensor.new_empty](https://pytorch.org/docs/stable/generated/torch.Tensor.new_empty.html)
-        so that Signal can be
-        [`deepcopy`](https://docs.python.org/3/library/copy.html#copy.deepcopy)ed.
+        so that
+        [`deepcopy`](https://docs.python.org/3/library/copy.html#copy.deepcopy)
+        can be run on Signal objects.
         """
 
         return super().new_empty(*args, **kwargs).as_subclass(self.__class__)

--- a/torchsynth/signal.py
+++ b/torchsynth/signal.py
@@ -22,7 +22,11 @@ class Signal(torch.Tensor):
         return self.shape[1]
 
     def new_empty(self, *args, **kwargs):
+        # noqa: E501
         """
-        Implement [torch.Tensor.new_empty](https://pytorch.org/docs/stable/generated/torch.Tensor.new_empty.html) so that Signal can be [`deepcopy`](https://docs.python.org/3/library/copy.html#copy.deepcopy)ed.
+            Implement
+        [torch.Tensor.new_empty](https://pytorch.org/docs/stable/generated/torch.Tensor.new_empty.html)
+        so that Signal can be
+        [`deepcopy`](https://docs.python.org/3/library/copy.html#copy.deepcopy)ed.
         """
         return super().new_empty(*args, **kwargs).as_subclass(self.__class__)


### PR DESCRIPTION
Some of the trivial changes are because of newer versions of black.

The new method `Signal.new_empty` and its test enable us to deepcopy Signals and thus checkpoint them.