### PR TITLE
PyTorch Lightning 2.0 Support

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -9,13 +9,13 @@ jobs:
 #        os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       OS: ${{ matrix.os }}
-      PYTHON: '3.7'
+      PYTHON: '3.8'
     steps:
     - uses: actions/checkout@master
     - name: Setup Python
       uses: actions/setup-python@master
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: apt-get
       run: |
         sudo apt-get install -y libsndfile-dev

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -6,17 +6,19 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: ammaraskar/sphinx-action@0.4
+    - uses: actions/checkout@v3
+    
+    - name: Setup Python
+      uses: actions/setup-python@v3
       with:
-        docs-folder: "docs/"
-#        pre-build-command: "apt-get update -y && apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended"
-#        build-command: "make latexpdf"
-    - uses: actions/upload-artifact@v1
-      with:
-        name: DocumentationHTML
-        path: docs/build/html/
-#    - uses: actions/upload-artifact@v1
-#      with:
-#        name: DocumentationPDF
-#        path: docs/build/pdf/
+        python-version: '3.9'
+
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        pip install -e ".[docs]"
+    
+    - name: Make Docs
+      shell: bash -l {0}
+      run: |
+        cd docs && make html

--- a/.github/workflows/sphinx-linkcheck.yml
+++ b/.github/workflows/sphinx-linkcheck.yml
@@ -24,7 +24,7 @@ jobs:
       - name: python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[docs]"
       - name: linkcheck
         shell: bash -l {0}
         run: |

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,4 +1,3 @@
 build:
-    environment:
-        python:
-            version: "3.10.13"
+  environment:
+    python: 3.8.0

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,4 +1,4 @@
 build:
     environment:
         python:
-            version: "3.10"
+            version: "3.10.13"

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,4 @@
+build:
+    environment:
+        python:
+            version: 3.10

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,4 +1,4 @@
 build:
     environment:
         python:
-            version: 3.10
+            version: "3.10"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,0 @@
-../requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,17 +3,35 @@
 # If we want to use snyk, we need a requirements.txt file
 # Otherwise we could just do this:
 #   https://stackoverflow.com/a/16624700/82733
+pre-commit
+nbstripout==0.6.0   # Used in precommit hooks
+black==22.6.0       # Used in precommit hooks
+jupytext==v1.10.3   # Used in precommit hooks
 numpy
 scipy
 torch>=1.8
-lightning
-sphinx~=4.2.0  # not directly required, pinned by Snyk to avoid a vulnerability
+pytorch-lightning
+# Doesn't support OrderedDict yet
+#typing-extensions
+pytest
+pytest-cov
+pytest-env
+ipython
+librosa
+matplotlib
+numba>=0.49.0 # not directly required, pinned by Snyk to avoid a vulnerability
+pygments>=2.7.4 # not directly required, pinned by Snyk to avoid a vulnerability
 unofficial-pt-lightning-sphinx-theme
-# Temporarily disabled so we can push to pypi
-# "pt-lightning-sphinx-theme @ https://github.com/PyTorchLightning/lightning_sphinx_theme/tarball/master#egg=pt-lightning-sphinx-theme",
+#git+https://github.com/PyTorchLightning/lightning_sphinx_theme
+#https://github.com/PyTorchLightning/lightning_sphinx_theme/tarball/master#egg=pt-lightning-sphinx-theme
 sphinxcontrib-napoleon
 sphinx-autodoc-typehints
+mock
 sphinx_rtd_theme
 myst_parser
 linkify-it-py
-mock
+sphinx>=3.0.4 # not directly required, pinned by Snyk to avoid a vulnerability
+myst-parser
+linkify-it-py
+scikit-learn>=0.24.2 # not directly required, pinned by Snyk to avoid a vulnerability
+setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ jupytext==v1.10.3   # Used in precommit hooks
 numpy
 scipy
 torch>=1.8
-pytorch-lightning
+lightning
 # Doesn't support OrderedDict yet
 #typing-extensions
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,35 +3,17 @@
 # If we want to use snyk, we need a requirements.txt file
 # Otherwise we could just do this:
 #   https://stackoverflow.com/a/16624700/82733
-pre-commit
-nbstripout==0.6.0   # Used in precommit hooks
-black==22.6.0       # Used in precommit hooks
-jupytext==v1.10.3   # Used in precommit hooks
 numpy
 scipy
 torch>=1.8
-pytorch-lightning
-# Doesn't support OrderedDict yet
-#typing-extensions
-pytest
-pytest-cov
-pytest-env
-ipython
-librosa
-matplotlib
-numba>=0.49.0 # not directly required, pinned by Snyk to avoid a vulnerability
-pygments>=2.7.4 # not directly required, pinned by Snyk to avoid a vulnerability
+lightning
+sphinx~=4.2.0  # not directly required, pinned by Snyk to avoid a vulnerability
 unofficial-pt-lightning-sphinx-theme
-#git+https://github.com/PyTorchLightning/lightning_sphinx_theme
-#https://github.com/PyTorchLightning/lightning_sphinx_theme/tarball/master#egg=pt-lightning-sphinx-theme
-MarkupSafe<2.1.0    # https://github.com/aws/aws-sam-cli/issues/3661
+# Temporarily disabled so we can push to pypi
+# "pt-lightning-sphinx-theme @ https://github.com/PyTorchLightning/lightning_sphinx_theme/tarball/master#egg=pt-lightning-sphinx-theme",
 sphinxcontrib-napoleon
 sphinx-autodoc-typehints
-mock
 sphinx_rtd_theme
 myst_parser
 linkify-it-py
-sphinx>=3.0.4 # not directly required, pinned by Snyk to avoid a vulnerability
-myst-parser
-linkify-it-py
-scikit-learn>=0.24.2 # not directly required, pinned by Snyk to avoid a vulnerability
+mock

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     package_data={"torchsynth": ["nebulae/voice/*.json"]},
     # package_dir={"": "src"},
     entry_points={"console_scripts": ["torchsynth.profile=torchsynth.profile:main"]},
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "numpy",
         "scipy",
@@ -66,17 +66,18 @@ setup(
             "numba>=0.49.0",  # not directly required, pinned by Snyk to avoid a vulnerability
             "pygments>=2.7.4",  # not directly required, pinned by Snyk to avoid a vulnerability
             "pytest-env",
-            "sphinx>=3.0.4",  # not directly required, pinned by Snyk to avoid a vulnerability
+        ],
+        "docs": [
+            "sphinx~=4.2.0",  # not directly required, pinned by Snyk to avoid a vulnerability
             "unofficial-pt-lightning-sphinx-theme",
             # Temporarily disabled so we can push to pypi
             # "pt-lightning-sphinx-theme @ https://github.com/PyTorchLightning/lightning_sphinx_theme/tarball/master#egg=pt-lightning-sphinx-theme",
-            "MarkupSafe<2.1.0",  # https://github.com/aws/aws-sam-cli/issues/3661
             "sphinxcontrib-napoleon",
             "sphinx-autodoc-typehints",
-            "mock",
             "sphinx_rtd_theme",
             "myst_parser",
             "linkify-it-py",
+            "mock",
         ],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "numpy",
         "scipy",
         "torch>=1.8",
-        "pytorch-lightning>=1.4",
+        "lightning",
         # pypi release (only master) doesn't support OrderedDict typing
         # "typing-extensions",
     ],

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "scipy",
         "torch>=1.8",
         "lightning",
+        "setuptools>=65.5.1",  # not directly required, pinned by Snyk to avoid a vulnerability
         # pypi release (only master) doesn't support OrderedDict typing
         # "typing-extensions",
     ],

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -4,6 +4,7 @@ Tests for torch synths
 
 import json
 import os
+import re
 
 import pytest
 import torch.nn
@@ -211,11 +212,18 @@ class TestAbstractSynth:
         assert torch.all(synth.keyboard.p("duration").isclose(dur_val))
 
         # Test randomization with synth with non-ModuleParameters raises error
-        synth.register_parameter("param", torch.nn.Parameter(tensor(0.0)))
-        with pytest.raises(ValueError, match="Param 0.0 is not a ModuleParameter"):
+        new_param = torch.nn.Parameter(tensor(0.0))
+        synth.register_parameter("param", new_param)
+        with pytest.raises(
+            ValueError,
+            match=re.escape(f"Param {repr(new_param)} is not a ModuleParameter"),
+        ):
             synth.randomize()
 
-        with pytest.raises(ValueError, match="Param 0.0 is not a ModuleParameter"):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(f"Param {repr(new_param)} is not a ModuleParameter"),
+        ):
             synth.randomize(1)
 
     def test_freeze_parameters(self):

--- a/torchsynth/profile.py
+++ b/torchsynth/profile.py
@@ -76,7 +76,7 @@ def run_lightning_module(
 ):
     mock_dataset = BatchIDXDataset(batch_size * n_batches)
     dataloader = torch.utils.data.DataLoader(
-        mock_dataset, num_workers=1, batch_size=batch_size, persistent_workers=True
+        mock_dataset, num_workers=0, batch_size=batch_size
     )
 
     if GPUS == 0 and device == "cuda":
@@ -90,8 +90,6 @@ def run_lightning_module(
         # specifies all available GPUs
         accelerator = "gpu"
         devices = -1
-        if GPUS > 1:
-            accelerator = "ddp"  # TODO: not sure if Lightning still accepts this
 
     print(f"Running on {accelerator} with {GPUS} GPUs")
     # Use deterministic?

--- a/torchsynth/synth.py
+++ b/torchsynth/synth.py
@@ -3,7 +3,7 @@
 :class:`~torchsynth.synth.Voice` is our default synthesizer, and is used to
 generate `synth1B1 <../reproducibility/synth1B1.html>`_.
 
-We base off pytorch-lightning :class:`~pytorch_lightning.core.lightning.LightningModule`
+We base off pytorch-lightning :class:`~lightning.LightningModule`
 because it makes `multi-GPU
 <https://pytorch-lightning.readthedocs.io/en/stable/accelerators/gpu.html>`_
 inference easy. Nonetheless, you can treat each synth as a native
@@ -26,7 +26,7 @@ else:
     from typing import Dict as OrderedDictType
 
 import torch
-from pytorch_lightning.core.lightning import LightningModule
+from lightning import LightningModule
 from torch import Tensor as T
 
 from torchsynth.config import N_BATCHSIZE_FOR_TRAIN_TEST_REPRODUCIBILITY, SynthConfig
@@ -270,8 +270,7 @@ class AbstractSynth(LightningModule):
     def test_step(self, batch, batch_idx):
         """
         This is boilerplate required by pytorch-lightning
-        :class:`~pytorch_lightning.LightningTrainer`
-        when calling test.
+        :class:`~lightning.Trainer` when calling test.
         """
         return 0.0
 


### PR DESCRIPTION
- Updates to use Lightning 2.0.
- Update minimum python version to 3.8
- Split out docs dependents and update sphinx CI tests