### PR TITLE
Sphinx Builds

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -9,13 +9,13 @@ jobs:
 #        os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       OS: ${{ matrix.os }}
-      PYTHON: '3.7'
+      PYTHON: '3.8'
     steps:
     - uses: actions/checkout@master
     - name: Setup Python
       uses: actions/setup-python@master
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: apt-get
       run: |
         sudo apt-get install -y libsndfile-dev

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.8, 3.10]
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.8, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/sphinx-build.yml
+++ b/.github/workflows/sphinx-build.yml
@@ -6,17 +6,19 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: ammaraskar/sphinx-action@0.4
+    - uses: actions/checkout@v3
+    
+    - name: Setup Python
+      uses: actions/setup-python@v3
       with:
-        docs-folder: "docs/"
-#        pre-build-command: "apt-get update -y && apt-get install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended"
-#        build-command: "make latexpdf"
-    - uses: actions/upload-artifact@v1
-      with:
-        name: DocumentationHTML
-        path: docs/build/html/
-#    - uses: actions/upload-artifact@v1
-#      with:
-#        name: DocumentationPDF
-#        path: docs/build/pdf/
+        python-version: '3.9'
+
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        pip install -e ".[docs]"
+    
+    - name: Make Docs
+      shell: bash -l {0}
+      run: |
+        cd docs && make html

--- a/.github/workflows/sphinx-linkcheck.yml
+++ b/.github/workflows/sphinx-linkcheck.yml
@@ -24,7 +24,7 @@ jobs:
       - name: python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[docs]"
       - name: linkcheck
         shell: bash -l {0}
         run: |

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,0 @@
-../requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,35 +3,17 @@
 # If we want to use snyk, we need a requirements.txt file
 # Otherwise we could just do this:
 #   https://stackoverflow.com/a/16624700/82733
-pre-commit
-nbstripout==0.6.0   # Used in precommit hooks
-black==22.6.0       # Used in precommit hooks
-jupytext==v1.10.3   # Used in precommit hooks
 numpy
 scipy
 torch>=1.8
-pytorch-lightning
-# Doesn't support OrderedDict yet
-#typing-extensions
-pytest
-pytest-cov
-pytest-env
-ipython
-librosa
-matplotlib
-numba>=0.49.0 # not directly required, pinned by Snyk to avoid a vulnerability
-pygments>=2.7.4 # not directly required, pinned by Snyk to avoid a vulnerability
+lightning
+sphinx~=4.2.0  # not directly required, pinned by Snyk to avoid a vulnerability
 unofficial-pt-lightning-sphinx-theme
-#git+https://github.com/PyTorchLightning/lightning_sphinx_theme
-#https://github.com/PyTorchLightning/lightning_sphinx_theme/tarball/master#egg=pt-lightning-sphinx-theme
-MarkupSafe<2.1.0    # https://github.com/aws/aws-sam-cli/issues/3661
+# Temporarily disabled so we can push to pypi
+# "pt-lightning-sphinx-theme @ https://github.com/PyTorchLightning/lightning_sphinx_theme/tarball/master#egg=pt-lightning-sphinx-theme",
 sphinxcontrib-napoleon
 sphinx-autodoc-typehints
-mock
 sphinx_rtd_theme
 myst_parser
 linkify-it-py
-sphinx>=3.0.4 # not directly required, pinned by Snyk to avoid a vulnerability
-myst-parser
-linkify-it-py
-scikit-learn>=0.24.2 # not directly required, pinned by Snyk to avoid a vulnerability
+mock

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     package_data={"torchsynth": ["nebulae/voice/*.json"]},
     # package_dir={"": "src"},
     entry_points={"console_scripts": ["torchsynth.profile=torchsynth.profile:main"]},
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "numpy",
         "scipy",
@@ -66,17 +66,18 @@ setup(
             "numba>=0.49.0",  # not directly required, pinned by Snyk to avoid a vulnerability
             "pygments>=2.7.4",  # not directly required, pinned by Snyk to avoid a vulnerability
             "pytest-env",
-            "sphinx>=3.0.4",  # not directly required, pinned by Snyk to avoid a vulnerability
+        ],
+        "docs": [
+            "sphinx~=4.2.0",  # not directly required, pinned by Snyk to avoid a vulnerability
             "unofficial-pt-lightning-sphinx-theme",
             # Temporarily disabled so we can push to pypi
             # "pt-lightning-sphinx-theme @ https://github.com/PyTorchLightning/lightning_sphinx_theme/tarball/master#egg=pt-lightning-sphinx-theme",
-            "MarkupSafe<2.1.0",  # https://github.com/aws/aws-sam-cli/issues/3661
             "sphinxcontrib-napoleon",
             "sphinx-autodoc-typehints",
-            "mock",
             "sphinx_rtd_theme",
             "myst_parser",
             "linkify-it-py",
+            "mock",
         ],
     },
     classifiers=[


### PR DESCRIPTION
- Creating a separate set of dependencies for building the Sphinx docs. Jupytext and document dependencies don't play nice.
- Bumping the minimum python version up to 3.8 to support minimum PTL requirement
- Updated the workflow for verifying doc builds work

This just fixes the test on documentation building. Will need address documentation deployment separately #424 